### PR TITLE
Set visible fails for child objects

### DIFF
--- a/src/angular-esri-map-toc.js
+++ b/src/angular-esri-map-toc.js
@@ -204,9 +204,10 @@
                                                     if (indexOfMatchingLayer !== -1) {
                                                         currentVisibleLayers.splice(indexOfMatchingLayer, 1);
                                                         //When removing child layer, remove group layer.
-                                                        if (currentLayer.layerInfos[indexOfMatchingLayer].parentLayerId !== -1)
+                                                        var parentLayerIndex = currentVisibleLayers.indexOf(currentLayer.layerInfos[indexOfMatchingLayer].parentLayerId);
+                                                        if (parentLayerIndex !== -1)
                                                         {
-                                                            currentVisibleLayers.splice(currentLayer.layerInfos[indexOfMatchingLayer].parentLayerId, 1);
+                                                            currentVisibleLayers.splice(parentLayerIndex, 1);
                                                         }
                                                     } else {
                                                         if (!layer.isParent && selectedNode.checked && layer.checked && layer.parentsChecked) {

--- a/src/angular-esri-map-toc.js
+++ b/src/angular-esri-map-toc.js
@@ -203,6 +203,11 @@
                                                     var indexOfMatchingLayer = currentVisibleLayers.indexOf(layer.layerId);
                                                     if (indexOfMatchingLayer !== -1) {
                                                         currentVisibleLayers.splice(indexOfMatchingLayer, 1);
+                                                        //When removing child layer, remove group layer.
+                                                        if (currentLayer.layerInfos[indexOfMatchingLayer].parentLayerId !== -1)
+                                                        {
+                                                            currentVisibleLayers.splice(currentLayer.layerInfos[indexOfMatchingLayer].parentLayerId, 1);
+                                                        }
                                                     } else {
                                                         if (!layer.isParent && selectedNode.checked && layer.checked && layer.parentsChecked) {
                                                             currentVisibleLayers.push(layer.layerId);


### PR DESCRIPTION
When removing item from currentVisibleLayers, also remove grouplayer. Otherwise the Layer won't be set visible.
See https://geonet.esri.com/thread/27093 for discussion of this issue.
